### PR TITLE
[CHANGE] Use `__NAMESPACE__` constant in autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Use `__NAMESPACE__` constant in autoloader
+
 ### Removed
 
 - Lazy-loading tweaks. WordPress has something built-in now.

--- a/Sources/autoload.php
+++ b/Sources/autoload.php
@@ -7,7 +7,7 @@ use RuntimeException;
 
 // Register the autoloader.
 // phpcs:disable
-spl_autoload_register(callback: '\Ppfeufer\Theme\Ppfeufer\autoload');
+spl_autoload_register(callback: '\\' . __NAMESPACE__ . '\autoload');
 // phpcs:enable
 
 /**


### PR DESCRIPTION
### Changed

- Use `__NAMESPACE__` constant in autoloader